### PR TITLE
Backward compatibility with older .NET versions

### DIFF
--- a/StringCompare/Algorithms/Tanimoto/TanimotoAlgorithm.cs
+++ b/StringCompare/Algorithms/Tanimoto/TanimotoAlgorithm.cs
@@ -5,6 +5,8 @@
 // Licensed under the MIT License (MIT)
 
 using StringCompare.Structures.Interfaces;
+using System;
+using System.Linq;
 
 namespace StringCompare.Algorithms.Tanimoto
 {
@@ -26,7 +28,7 @@ namespace StringCompare.Algorithms.Tanimoto
             source = source ?? string.Empty;
             target = target ?? string.Empty;
 
-            if (string.IsNullOrWhiteSpace(source) && string.IsNullOrWhiteSpace(target)) return 1;
+            if (IsNullOrWhiteSpace(source) && IsNullOrWhiteSpace(target)) return 1;
 
             double sourceLength = source.Length;
             double targetLength = target.Length;
@@ -38,6 +40,17 @@ namespace StringCompare.Algorithms.Tanimoto
             }
 
             return commonsCount / (sourceLength + targetLength - commonsCount);
+        }
+
+        /// <summary>
+        /// Provided here for backward compatibility with older .NET versions.
+        /// See: http://referencesource.microsoft.com/#mscorlib/system/string.cs,55e241b6143365ef
+        /// </summary>
+        /// <param name="value"></param>
+        /// <returns></returns>
+        private static bool IsNullOrWhiteSpace(string value)
+        {
+            return value == null || value.All(Char.IsWhiteSpace);
         }
     }
 }

--- a/StringCompare/NuGet.Pack.bat
+++ b/StringCompare/NuGet.Pack.bat
@@ -1,1 +1,1 @@
-nuget pack StringCompare.csproj -Prop Configuration=Release
+nuget pack StringCompare.nuspec -Prop Configuration=Release

--- a/StringCompare/StringCompare.csproj
+++ b/StringCompare/StringCompare.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>StringCompare</RootNamespace>
     <AssemblyName>StringCompare</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,11 +32,11 @@
     <DocumentationFile>bin\Release\StringCompare.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="LinqBridge, Version=1.3.0.0, Culture=neutral, PublicKeyToken=c2b14eb747628076, processorArchitecture=MSIL">
+      <HintPath>..\packages\LinqBridge.1.3.0\lib\net20\LinqBridge.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/StringCompare/StringCompare.nuspec
+++ b/StringCompare/StringCompare.nuspec
@@ -23,5 +23,14 @@ In this version allow:
 - Hamming distance</summary>
     <copyright>Copyright (C) 2015 Nick Rimmer. Contacts: &lt;xan@dipteam.com&gt;</copyright>
     <tags>strings, levenshtein, tanimoto, Hamming</tags>
+    <dependencies>
+      <group targetFramework="net20">
+        <dependency id="LinqBridge"  version="1.3.0" />
+      </group>
+      <group targetFramework="net35" />
+    </dependencies>
   </metadata>
+  <files>
+    <file src="bin\Release\StringCompare.dll" target="lib\net20" />
+  </files>
 </package>

--- a/StringCompare/packages.config
+++ b/StringCompare/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LinqBridge" version="1.3.0" targetFramework="net20" />
+</packages>


### PR DESCRIPTION
I modified the project to work with .NET 2.0, 3.0 and 3.5 (yes, some people are still stuck with legacy code :(... )
1. Modified nuspec file to include LinqBridge as a dependency for .NET 2.0 and .NET 3.0. This provides `System.Linq` namespace.
2. Changed `string.IsNullOrWhiteSpace` to private static method in `TanimotoAlgorithm`. `IsNullOrWhiteSpace` was added in .NET 4.0
3. Removed unused dll references
